### PR TITLE
Sct 1095

### DIFF
--- a/kbase.yml
+++ b/kbase.yml
@@ -8,7 +8,7 @@ service-language:
     python
 
 module-version:
-    1.1.0
+    1.1.1
 
 owners:
     [tgu2]

--- a/lib/GenomeFileUtil/GenomeFileUtilClient.py
+++ b/lib/GenomeFileUtil/GenomeFileUtilClient.py
@@ -25,7 +25,7 @@ class GenomeFileUtil(object):
             password=None, token=None, ignore_authrc=False,
             trust_all_ssl_certificates=False,
             auth_svc='https://kbase.us/services/authorization/Sessions/Login',
-            service_ver='release',
+            service_ver='beta',
             async_job_check_time_ms=100, async_job_check_time_scale_percent=150, 
             async_job_check_max_time_ms=300000):
         if url is None:

--- a/lib/kb_stringtie/Utils/StringTieUtil.py
+++ b/lib/kb_stringtie/Utils/StringTieUtil.py
@@ -224,7 +224,8 @@ class StringTieUtil:
             ret = self.au.get_assembly_as_fasta({'ref': contig_id})
             fa_output_file = ret['path']
 
-            shutil.copy(fa_output_file, result_directory)
+            if os.path.dirname(fa_output_file) != result_directory:
+                shutil.copy(fa_output_file, result_directory)
 
             # get the GFF
             ret = self.gfu.genome_to_gff({'genome_ref': genome_ref,
@@ -670,6 +671,16 @@ class StringTieUtil:
                                                                     'include_item_info': 0,
                                                                     'include_set_item_ref_paths': 1
                                                                     })
+        # pull down the genome once so as to avoid duplicate effort
+        if not params.get('gtf_file'):
+            alignment_ref = alignment_set["data"]["items"][0]["ref_path"]
+            params['gtf_file'] = self._get_gtf_file(alignment_ref, self.scratch)
+            if params.get('label'):
+                if params['label'] in open(params['gtf_file']).read():
+                    raise ValueError("Provided prefix for transcripts matches an existing "
+                                     "feature ID. Please select a different label for "
+                                     "transcripts.")
+
         mul_processor_params = []
         for alignment in alignment_set["data"]["items"]:
             alignment_ref = alignment['ref_path']

--- a/ui/narrative/methods/run_stringtie/display.yaml
+++ b/ui/narrative/methods/run_stringtie/display.yaml
@@ -1,7 +1,7 @@
 #
 # Define basic display information
 #
-name     : Assemble Transcripts using StringTie - v1.0.9
+name     : Assemble Transcripts using StringTie - v1.3.3b
 
 tooltip  : |
     Assemble the transcripts from RNA-seq reads using StringTie


### PR DESCRIPTION
This PR fixes a few things:
* Use a version of GFU that always generates the GFF file (rather than using a cached file)
* Update the UI to have Stringtie version in the app name
* Only download the genome for a genome set once to improve efficiency and reduce risk of runtime errors.